### PR TITLE
Fix simen.md javascript attribution

### DIFF
--- a/posts/simen.md
+++ b/posts/simen.md
@@ -6,3 +6,4 @@ Simen Bekkhus is a living Github.com legend, known for his many Makefile-improve
 contributions to well known C/C++ projects. Including, but not limited to: GCC, Clang,
 Android Open Source project and the Linux Kernel.
 
+Simen Bekkhus also, according to rumours, contribute to JavaScript projects. There he's known as Simen "package.json" Bekkhus. [These rumours have never been officially confirmed by third-party sources](https://github.com/search?l=JSON&q=user%3Asimenb+filename%3Apackage.json&type=Code), so take them with a grain of salt.


### PR DESCRIPTION
Simen.md doesn't mention possible contributions to JavaScript projects.